### PR TITLE
[FEAT] Portal, Modal 컴포넌트 구현

### DIFF
--- a/apps/storybook/stories/Modal.stories.tsx
+++ b/apps/storybook/stories/Modal.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Modal } from '@repo/ui/Modal';
+import { useState } from 'react';
+
+const meta = {
+  title: 'components/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Basic: Story = {
+  args: {
+    isOpen: false,
+    onClickOutside: () => {},
+    children: '',
+  },
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState<boolean>(args.isOpen);
+    const onClickOutside = () => setIsOpen((prev) => !prev);
+
+    return (
+      <>
+        <button onClick={onClickOutside}>Open Modal</button>
+        <Modal {...args} isOpen={isOpen} onClickOutside={onClickOutside}>
+          <div className="flex flex-col items-center justify-center gap-2">
+            <h1 className="text-center text-xl font-semibold">이미 등록된 책입니다.</h1>
+            <span className="mb-4 whitespace-pre-line text-center text-base font-normal text-gray-400">
+              {`책장에 같은 책이 존재합니다.\n다시 등록하시겠어요?`}
+            </span>
+            <button
+              onClick={onClickOutside}
+              className="h-12 w-full rounded-xl bg-gray-100 text-gray-400"
+            >
+              닫기
+            </button>
+          </div>
+        </Modal>
+      </>
+    );
+  },
+};

--- a/apps/storybook/stories/Modal.stories.tsx
+++ b/apps/storybook/stories/Modal.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Modal } from '@repo/ui/Modal';
-import { useState } from 'react';
+
+import { useModal } from '@repo/ui/hooks/useModal';
 
 const meta = {
   title: 'components/Modal',
@@ -15,23 +16,33 @@ export const Basic: Story = {
   args: {
     isOpen: false,
     onClickOutside: () => {},
-    children: '',
+    children: 'Modal Content',
   },
-  render: (args) => {
-    const [isOpen, setIsOpen] = useState<boolean>(args.isOpen);
-    const onClickOutside = () => setIsOpen((prev) => !prev);
+  argTypes: {
+    isOpen: {
+      control: false,
+    },
+    onClickOutside: {
+      control: false,
+    },
+    children: {
+      control: false,
+    },
+  },
+  render: () => {
+    const { isOpen, openModal, closeModal } = useModal();
 
     return (
       <>
-        <button onClick={onClickOutside}>Open Modal</button>
-        <Modal {...args} isOpen={isOpen} onClickOutside={onClickOutside}>
+        <button onClick={openModal}>Open Modal</button>
+        <Modal isOpen={isOpen} onClickOutside={closeModal}>
           <div className="flex flex-col items-center justify-center gap-2">
             <h1 className="text-center text-xl font-semibold">이미 등록된 책입니다.</h1>
             <span className="mb-4 whitespace-pre-line text-center text-base font-normal text-gray-400">
               {`책장에 같은 책이 존재합니다.\n다시 등록하시겠어요?`}
             </span>
             <button
-              onClick={onClickOutside}
+              onClick={closeModal}
               className="h-12 w-full rounded-xl bg-gray-100 text-gray-400"
             >
               닫기

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -4,6 +4,7 @@
     "baseUrl": ".",
     "paths": {
       "@repo/ui/*": ["../../packages/ui/src/components/*"],
+      "@repo/ui/hooks/*": ["../../packages/ui/src/hooks/*"],
       "@/lib/*": ["../../packages/ui/src/lib/*"]
     }
   },

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@repo/ui/*": ["../../packages/ui/src/components/*"]
+      "@repo/ui/*": ["../../packages/ui/src/components/*"],
+      "@/lib/*": ["../../packages/ui/src/lib/*"]
     }
   },
   "include": ["stories/**/*.tsx", "stories/**/*.ts", ".storybook/**/*"]

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -1,0 +1,51 @@
+import { motion } from 'framer-motion';
+
+import { FADE_IN_ANIMATION } from '@/lib/motions';
+
+import { Portal } from '../Portal';
+
+import { Content } from './ModalContent';
+
+type Props = {
+  /**
+   * Indicates whether the modal is currently open.
+   * @default false
+   */
+  isOpen: boolean;
+  /**
+   * optional, can be used to handle modal closing or other actions.
+   */
+  onClickOutside?: VoidFunction;
+  /**
+   * optional, can be used to display a graphic in the modal.
+   * @default false
+   */
+  graphic?: boolean;
+  /**
+   * The content to be displayed inside the modal.
+   */
+  children: React.ReactNode;
+};
+
+export function Modal({ isOpen, onClickOutside, graphic = false, children }: Props) {
+  const onClickOutsideDefault = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target instanceof HTMLElement && e.target === e.currentTarget && onClickOutside) {
+      onClickOutside();
+    }
+  };
+
+  return (
+    <Portal isOpen={isOpen} mode="wait">
+      <motion.div
+        onClick={onClickOutsideDefault}
+        variants={FADE_IN_ANIMATION}
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        className="fixed inset-0 z-50 flex items-center justify-center bg-gray-800 bg-opacity-50"
+      >
+        <Content graphic={graphic}>{children}</Content>
+      </motion.div>
+    </Portal>
+  );
+}

--- a/packages/ui/src/components/Modal/Modal.tsx
+++ b/packages/ui/src/components/Modal/Modal.tsx
@@ -1,3 +1,5 @@
+import { ComponentProps } from 'react';
+
 import { motion } from 'framer-motion';
 
 import { FADE_IN_ANIMATION } from '@/lib/motions';
@@ -15,7 +17,7 @@ type Props = {
   /**
    * optional, can be used to handle modal closing or other actions.
    */
-  onClickOutside?: VoidFunction;
+  onClickOutside: VoidFunction;
   /**
    * optional, can be used to display a graphic in the modal.
    * @default false
@@ -25,7 +27,7 @@ type Props = {
    * The content to be displayed inside the modal.
    */
   children: React.ReactNode;
-};
+} & ComponentProps<'div'>;
 
 export function Modal({ isOpen, onClickOutside, graphic = false, children }: Props) {
   const onClickOutsideDefault = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/ui/src/components/Modal/ModalContent.tsx
+++ b/packages/ui/src/components/Modal/ModalContent.tsx
@@ -1,0 +1,21 @@
+type ContentProps = {
+  /**
+   * optional, can be used to display a graphic in the modal.
+   * @default false
+   */
+  graphic?: boolean;
+  /**
+   * The content to be displayed inside the modal.
+   */
+  children: React.ReactNode;
+} & React.HTMLAttributes<HTMLDivElement>;
+
+export function Content({ graphic, children }: ContentProps) {
+  return (
+    <div
+      className={`relative z-50 w-80 rounded-2xl bg-white pb-6 pt-8 shadow-lg ${graphic ? 'px-5' : 'px-6'}`}
+    >
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/components/Modal/index.ts
+++ b/packages/ui/src/components/Modal/index.ts
@@ -1,0 +1,1 @@
+export { Modal } from './Modal';

--- a/packages/ui/src/components/Portal/Portal.tsx
+++ b/packages/ui/src/components/Portal/Portal.tsx
@@ -1,0 +1,37 @@
+import { PropsWithChildren, useEffect, useState } from 'react';
+
+import { AnimatePresence } from 'framer-motion';
+import { createPortal } from 'react-dom';
+
+export function PortalWrapper({ children }: PropsWithChildren) {
+  const [container, setContainer] = useState<Element | null>(null);
+
+  useEffect(() => {
+    setContainer(document.body);
+  }, []);
+
+  if (!container) return null;
+
+  return createPortal(<>{children}</>, container);
+}
+
+type Props = {
+  /**
+   * Indicates whether the modal is currently open.
+   * @default false
+   */
+  isOpen: boolean;
+  /**
+   * The content to render within the portal.
+   *  @default 'wait'
+   */
+  mode?: 'wait' | 'sync' | 'popLayout';
+} & PropsWithChildren;
+
+export function Portal({ isOpen, mode = 'wait', children }: PropsWithChildren<Props>) {
+  return (
+    <PortalWrapper>
+      <AnimatePresence mode={mode}>{isOpen && children}</AnimatePresence>
+    </PortalWrapper>
+  );
+}

--- a/packages/ui/src/components/Portal/index.ts
+++ b/packages/ui/src/components/Portal/index.ts
@@ -1,0 +1,1 @@
+export { Portal } from './Portal';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,2 +1,4 @@
 export { Button } from './Button';
 export { Text } from './Text';
+export { Portal } from './Portal';
+export { Modal } from './Modal';

--- a/packages/ui/src/hooks/useModal.ts
+++ b/packages/ui/src/hooks/useModal.ts
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+export const useModal = () => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+
+  const handleOpen = () => setIsOpen(true);
+  const handleClose = () => setIsOpen(false);
+
+  return {
+    isOpen,
+    openModal: handleOpen,
+    closeModal: handleClose,
+  };
+};

--- a/packages/ui/src/lib/motions.ts
+++ b/packages/ui/src/lib/motions.ts
@@ -1,0 +1,5 @@
+export const FADE_IN_ANIMATION = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #14

## ✨ 작업 내용

- Portal, Modal 컴포넌트 구현했습니다.
- `createPortal` 사용하여  모달을 `document.body`에 직접 추가하여, 부모 요소에 영향을 받지 않도록 구현했습니다.
- `AnimatePresence`의 `mode="wait"` 을 사용해서 이전 애니메이션이 끝날때까지 새로운 요소가 추가되지 않도록 구현했습니다.
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

https://github.com/user-attachments/assets/76e53ff5-6766-471a-aa84-fc64a970f010




## 🙏 기타 참고 사항
- 디자이너 분들께서 `graphic`의 유무에 따라 모달 내 패딩이 달라진다고 하셨어요. `graphic` 여부에 따라 패딩 차이를 줬습니다.
- 모달 background-color 관련해서는 아직 color Palette가 없어서 임시로 진행했습니다.

<!-- 없다면 적지 않으셔도 됩니다. -->