### PR TITLE
[FEAT] Drawer 컴포넌트 구현

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -16,8 +16,9 @@ export default function RootLayout({
   return (
     <html lang="ko" className={`${pretendard.variable}`}>
       <body className={pretendard.className}>
-        {children}
-        <div className="text-blue-800">아아아</div>
+        <div className="flex h-dvh justify-center">
+          <div className="mx-4 w-full max-w-[375px]">{children}</div>
+        </div>
       </body>
     </html>
   );

--- a/packages/ui/src/components/Drawer/Drawer.tsx
+++ b/packages/ui/src/components/Drawer/Drawer.tsx
@@ -1,0 +1,41 @@
+import { PropsWithChildren } from 'react';
+
+import { motion } from 'framer-motion';
+
+import { FADE_IN_ANIMATION, SLIDE_IN_ANIMATION } from '@/lib/motions';
+
+import { Portal } from '../Portal';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+} & PropsWithChildren;
+
+export function Drawer({ isOpen, onClose, children }: Props) {
+  return (
+    <Portal isOpen={isOpen} mode="wait">
+      <motion.div
+        key="drawer-overlay"
+        className="fixed inset-0 bg-black/50"
+        initial={FADE_IN_ANIMATION.initial}
+        animate={FADE_IN_ANIMATION.animate}
+        exit={FADE_IN_ANIMATION.exit}
+        onClick={onClose}
+      />
+      <div
+        onClick={onClose}
+        className="fixed right-0 top-0 h-full overflow-hidden md:right-[calc((100vw-375px)/2)]"
+      >
+        <motion.div
+          className="h-full w-[242px] bg-white shadow-lg"
+          initial={SLIDE_IN_ANIMATION.initial}
+          animate={SLIDE_IN_ANIMATION.animate}
+          exit={SLIDE_IN_ANIMATION.exit}
+          transition={SLIDE_IN_ANIMATION.transition}
+        >
+          {children}
+        </motion.div>
+      </div>
+    </Portal>
+  );
+}

--- a/packages/ui/src/components/Drawer/index.ts
+++ b/packages/ui/src/components/Drawer/index.ts
@@ -1,0 +1,1 @@
+export { Drawer } from './Drawer';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,8 +1,9 @@
-export { Button } from './Button';
-export { Text } from './Text';
-export { Portal } from './Portal';
-export { Modal } from './Modal';
+export * from './Button';
+export * from './Text';
+export * from './Portal';
+export * from './Modal';
 export * from './IconButton';
 export * from './Header';
 export * from './Layout';
 export * from './Icon';
+export * from './Drawer';

--- a/packages/ui/src/lib/motions.ts
+++ b/packages/ui/src/lib/motions.ts
@@ -3,3 +3,10 @@ export const FADE_IN_ANIMATION = {
   animate: { opacity: 1 },
   exit: { opacity: 0 },
 };
+
+export const SLIDE_IN_ANIMATION = {
+  initial: { translateX: '100%' },
+  animate: { translateX: 0 },
+  exit: { translateX: '100%' },
+  transition: { type: 'tween', damping: 50 },
+};


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #24 

## ✨ 작업 내용

- `relative` 연결이 효율적일지 `Portal`로 분리하여 관리하는게 효율적일지 고민하다가 이미 `Portal` 컴포넌트가 존재하고  에셋이나 다른 UI의 `z-index` 고려 등의 이유로 `Portal`로 관리하는 방식 채택했습니다~!
- `relative`를 사용하지 않고 Layout의 크기에 맞춰 Drawer 컴포넌트 구성을 진행하다 보니 스토리북 구현 상 적절하지 않아서 제외했습니다.

https://github.com/user-attachments/assets/8a71a8e7-a384-4fb2-818f-f1482f875340



<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->