### PR TITLE
[FEAT] 닉네임 설정 페이지 api 연동

### DIFF
--- a/apps/web/app/_api/auth.ts
+++ b/apps/web/app/_api/auth.ts
@@ -5,6 +5,7 @@ export const authRepository = {
     instance.post<{
       data: {
         memberId: string;
+        nickname: string;
       };
     }>('auth/reissue', {
       headers: {

--- a/apps/web/app/_api/mutations/useNickname.ts
+++ b/apps/web/app/_api/mutations/useNickname.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { fetcher } from '../fetcher';
+
+const updateNicknameAPI = (data: { nickname: string }) =>
+  fetcher.post('members/onboarding', { json: data });
+
+export const useNickname = () => {
+  return useMutation({
+    mutationFn: updateNicknameAPI,
+    // TODO : 에러 시 토스트
+    onError: () => {},
+  });
+};

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -16,11 +16,11 @@ export async function GET(request: NextRequest) {
     }
 
     cookieList.set(COOKIE_ID.REFRESH_TOKEN, refreshToken);
-    //TODO 닉네임 여부에 따라 닉네임 설정 페이지로 갈지 홈페이지로 갈지 로직 구현 필요
+
     const response = await authRepository.reissue(refreshToken);
 
     const {
-      data: { memberId },
+      data: { memberId, nickname },
     } = await response.json();
 
     const accessToken = response.headers.get('Authorization')?.replace('Bearer ', '');
@@ -32,7 +32,11 @@ export async function GET(request: NextRequest) {
     cookieList.set('accessToken', accessToken);
     cookieList.set('memberId', memberId);
 
-    return NextResponse.redirect(new URL('/', request.url));
+    if (nickname) {
+      return NextResponse.redirect(new URL('/home', request.url));
+    }
+
+    return NextResponse.redirect(new URL('/nickname', request.url));
   } catch (error) {
     console.warn(error);
     return NextResponse.redirect(new URL('/login?error=auth_failed', request.url));

--- a/apps/web/app/nickname/page.tsx
+++ b/apps/web/app/nickname/page.tsx
@@ -9,15 +9,17 @@ import { Header } from '@repo/ui/components/Header';
 import { Box, JustifyBetween, PageLayout, Stack } from '@repo/ui/components/Layout';
 import { Text } from '@repo/ui/components/Text';
 import { TextField } from '@repo/ui/components/TextField';
+import { useNickname } from 'app/_api/mutations/useNickname';
 
 const INITIAL_NICKNAME = '';
 
 const NicknamePage = () => {
   const router = useRouter();
 
-  const onClickSaveButton = () => {
-    //TODO 닉네임 저장 api 연동
+  const { mutate, isPending } = useNickname();
 
+  const onClickSaveButton = () => {
+    mutate({ nickname });
     router.push('/onboarding');
   };
 
@@ -29,7 +31,7 @@ const NicknamePage = () => {
 
   const onReset = () => setNickname(INITIAL_NICKNAME);
 
-  const disabled = nickname.length === 0;
+  const disabled = nickname.length === 0 || isPending;
 
   const ref = useCallback((node: HTMLInputElement | null) => {
     node?.focus();


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #84

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
- 닉네임 설정 페이지 api를 연동했습니다
- 로그인 시 닉네임 여부에 따라 /home 또는 /nickname으로 이동하도록 설정했습니다
- 위의 로그인 시 닉네임은 따로 저장하지 않습니다.

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->