### PR TITLE
[FEAT] 평가 페이지 api 추가

### DIFF
--- a/apps/web/app/_api/mutations/useUpdateEvaluation.ts
+++ b/apps/web/app/_api/mutations/useUpdateEvaluation.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { fetcher } from '../fetcher';
+import { UpdateBookEvaluationRequest } from '../types/evaluation';
+
+const updateEvaluationAPI = ({ bookId, keywordIds }: UpdateBookEvaluationRequest) =>
+  fetcher.put(`books/${bookId}/evaluation`, {
+    json: {
+      keywordIds,
+    },
+  });
+
+export const useUpdateEvaluation = () => {
+  return useMutation({
+    mutationFn: updateEvaluationAPI,
+    // TODO : 에러 시 토스트
+    onError: () => {},
+  });
+};

--- a/apps/web/app/_api/mutations/useUpdateEvaluation.ts
+++ b/apps/web/app/_api/mutations/useUpdateEvaluation.ts
@@ -1,6 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { fetcher } from '../fetcher';
+import { evaluaionQueryKeys } from '../queries/evaluation';
 import { UpdateBookEvaluationRequest } from '../types/evaluation';
 
 const updateEvaluationAPI = ({ bookId, keywordIds }: UpdateBookEvaluationRequest) =>
@@ -11,9 +12,15 @@ const updateEvaluationAPI = ({ bookId, keywordIds }: UpdateBookEvaluationRequest
   });
 
 export const useUpdateEvaluation = () => {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateEvaluationAPI,
     // TODO : 에러 시 토스트
     onError: () => {},
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [...evaluaionQueryKeys.all()],
+      });
+    },
   });
 };

--- a/apps/web/app/_api/queries/evaluation.ts
+++ b/apps/web/app/_api/queries/evaluation.ts
@@ -1,0 +1,23 @@
+import { queryOptions } from '@tanstack/react-query';
+
+import { fetcher } from '../fetcher';
+import {
+  GetBookEvaluationListAPIRequest,
+  GetBookEvaluationListAPIResponse,
+} from '../types/evaluation';
+
+export const evaluaionQueryKeys = {
+  all: () => ['evaluaion'],
+  lists: () => [...evaluaionQueryKeys.all(), 'list'],
+};
+
+export const evaluaionQueryOptions = {
+  list: (bookId: string) =>
+    queryOptions({
+      queryKey: [...evaluaionQueryKeys.lists(), bookId],
+      queryFn: () => getBookEvaluationListAPI({ bookId }),
+    }),
+};
+
+const getBookEvaluationListAPI = ({ bookId }: GetBookEvaluationListAPIRequest) =>
+  fetcher.get<GetBookEvaluationListAPIResponse>(`books/${bookId}/evaluation`);

--- a/apps/web/app/_api/types/evaluation.ts
+++ b/apps/web/app/_api/types/evaluation.ts
@@ -1,0 +1,20 @@
+import { ResponseFormat } from './response';
+
+export type GetBookEvaluationListAPIRequest = {
+  bookId: string;
+};
+
+type Evaluation = {
+  evaluationId: number;
+  type: string;
+  keyword: string;
+  icon: string;
+  isSelected: boolean;
+};
+
+export type GetBookEvaluationListAPIResponse = ResponseFormat<Evaluation[]>;
+
+export type UpdateBookEvaluationRequest = {
+  bookId: string;
+  keywordIds: string[];
+};

--- a/apps/web/app/_api/types/evaluation.ts
+++ b/apps/web/app/_api/types/evaluation.ts
@@ -4,7 +4,7 @@ export type GetBookEvaluationListAPIRequest = {
   bookId: string;
 };
 
-type Evaluation = {
+export type Evaluation = {
   evaluationId: number;
   type: string;
   keyword: string;

--- a/apps/web/app/_api/types/evaluation.ts
+++ b/apps/web/app/_api/types/evaluation.ts
@@ -16,5 +16,5 @@ export type GetBookEvaluationListAPIResponse = ResponseFormat<Evaluation[]>;
 
 export type UpdateBookEvaluationRequest = {
   bookId: string;
-  keywordIds: string[];
+  keywordIds: number[];
 };

--- a/apps/web/app/books/[id]/_components/DialogTrigger.tsx
+++ b/apps/web/app/books/[id]/_components/DialogTrigger.tsx
@@ -37,6 +37,7 @@ export const DialogTrigger = ({ data }: DialogTriggerProps) => {
           closeModal={closeModal}
           data={data}
           onConfirm={onConfirm}
+          initialReadState={data.readStatus}
         />
       )}
     </>

--- a/apps/web/app/books/[id]/_components/KeywordSection.tsx
+++ b/apps/web/app/books/[id]/_components/KeywordSection.tsx
@@ -1,36 +1,57 @@
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+
+import { useQuery } from '@tanstack/react-query';
+
 import { Button } from '@repo/ui/components/Button';
 import { Chip } from '@repo/ui/components/Chip';
 import { Icon } from '@repo/ui/components/Icon';
 import { Box, CenterStack, HStack, Spacing, Stack } from '@repo/ui/components/Layout';
 import { Text } from '@repo/ui/components/Text';
+import { evaluaionQueryOptions } from 'app/_api/queries/evaluation';
+import { MemberBook } from 'app/_api/types/book';
+import { getChipIconUrl } from 'app/books/_utils/getChipIconUrl';
 
-import { MOCK_TAG } from '../_fixture/hashTag';
+type Props = MemberBook;
 
-export const KeywordSection = () => {
+export const KeywordSection = ({ id }: Props) => {
+  const router = useRouter();
+
+  const goReviewPage = () => router.push(`/books/${id}/review`);
+
+  const { isPending, data } = useQuery(evaluaionQueryOptions.list(id));
+  const keywordList = data?.data.filter(({ isSelected }) => isSelected);
+  const isEmptyKeywordList = keywordList?.length === 0;
+
   return (
     <>
       <Box className="h-[1px] bg-gray-100" />
-      <EmptyReview />
-      <Stack className="gap-4">
-        <HStack className="gap-2">
-          <Text type="Title1" weight="semibold" className="text-gray-600">
-            내 평가
-          </Text>
-          <Icon type="squarePen" />
-        </HStack>
-        <HStack className="flex-wrap gap-x-3 gap-y-2.5">
-          {MOCK_TAG.map((text, index) => (
-            <Chip key={index} variant="keyword" active={false} className="gap-1">
-              {text}
-            </Chip>
-          ))}
-        </HStack>
-      </Stack>
+      {!isPending &&
+        (isEmptyKeywordList ? (
+          <EmptyReview onClickReviewButon={goReviewPage} />
+        ) : (
+          <Stack className="gap-4">
+            <HStack className="gap-2">
+              <Text type="Title1" weight="semibold" className="text-gray-600">
+                내 평가
+              </Text>
+              <Icon type="squarePen" />
+            </HStack>
+            <HStack className="flex-wrap gap-x-3 gap-y-2.5">
+              {keywordList?.map(({ icon, keyword, evaluationId }) => (
+                <Chip key={evaluationId} variant="keyword" active={false} className="gap-1">
+                  <Image src={getChipIconUrl(icon)} alt="keyword" width={20} height={20} />
+                  {keyword}
+                </Chip>
+              ))}
+            </HStack>
+          </Stack>
+        ))}
     </>
   );
 };
 
-const EmptyReview = () => {
+const EmptyReview = ({ onClickReviewButon }: { onClickReviewButon: VoidFunction }) => {
   return (
     <CenterStack className="py-2">
       <Text type="Title1" weight="semibold" className="text-gray-900">
@@ -41,7 +62,9 @@ const EmptyReview = () => {
         완독한 책을 평가하고 구슬을 받으세요.
       </Text>
       <Spacing className="h-4" />
-      <Button className="my-1">평가하기</Button>
+      <Button className="my-1" onClick={onClickReviewButon}>
+        평가하기
+      </Button>
     </CenterStack>
   );
 };

--- a/apps/web/app/books/[id]/_components/KeywordSection.tsx
+++ b/apps/web/app/books/[id]/_components/KeywordSection.tsx
@@ -35,7 +35,9 @@ export const KeywordSection = ({ id }: Props) => {
               <Text type="Title1" weight="semibold" className="text-gray-600">
                 내 평가
               </Text>
-              <Icon type="squarePen" />
+              <button onClick={goReviewPage}>
+                <Icon type="squarePen" />
+              </button>
             </HStack>
             <HStack className="flex-wrap gap-x-3 gap-y-2.5">
               {keywordList?.map(({ icon, keyword, evaluationId }) => (

--- a/apps/web/app/books/[id]/_components/ReadingCard.tsx
+++ b/apps/web/app/books/[id]/_components/ReadingCard.tsx
@@ -34,7 +34,7 @@ export const ReadingCard = (props: Props) => {
         </HStack>
         <DialogTrigger data={props} />
       </JustifyBetween>
-      <KeywordSection />
+      {readStatus === 'COMPLETED' && <KeywordSection {...props} />}
     </Stack>
   );
 };

--- a/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
+++ b/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
@@ -60,7 +60,7 @@ export const ReviewContent = ({ id }: { id: string }) => {
     setSelectedKeywordIdList((prev) => [...prev, keywordId]);
   };
 
-  const resetSelectedKeywordIdList = () => setSelectedKeywordIdList([]);
+  const resetSelectedKeywordIdList = () => setSelectedKeywordIdList(initialKeywordList);
 
   const { mutate } = useUpdateEvaluation();
 
@@ -72,7 +72,12 @@ export const ReviewContent = ({ id }: { id: string }) => {
     router.push(`/books/${id}`);
   };
 
-  //TODO 이전 상태와 같거나 선택 아예 안했을때 비활성화
+  const areInitialKeywordListAndSelectedKeywordIdListArrayEqual = areArraysEqual(
+    initialKeywordList,
+    selectedKeywordIdList
+  );
+  const disabled =
+    selectedKeywordIdList.length === 0 || areInitialKeywordListAndSelectedKeywordIdListArrayEqual;
 
   return (
     <Stack className="gap-5 px-4 pb-4">
@@ -107,13 +112,24 @@ export const ReviewContent = ({ id }: { id: string }) => {
           variant="gray200"
           className="grow"
           onClick={resetSelectedKeywordIdList}
+          disabled={areInitialKeywordListAndSelectedKeywordIdListArrayEqual}
         >
           초기화
         </Button>
-        <Button variant="black" className="grow" onClick={onClickSaveButton}>
+        <Button variant="black" className="grow" onClick={onClickSaveButton} disabled={disabled}>
           완료하기
         </Button>
       </HStack>
     </Stack>
   );
+};
+
+const areArraysEqual = (array1: number[], array2: number[]): boolean => {
+  if (array1.length !== array2.length) {
+    return false;
+  }
+
+  const combinedSet = new Set([...array1, ...array2]);
+
+  return combinedSet.size === array1.length;
 };

--- a/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
+++ b/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
 import { useState } from 'react';
 
@@ -10,6 +11,7 @@ import { Button } from '@repo/ui/components/Button';
 import { Chip } from '@repo/ui/components/Chip';
 import { HStack, Stack } from '@repo/ui/components/Layout';
 import { Text } from '@repo/ui/components/Text';
+import { useUpdateEvaluation } from 'app/_api/mutations/useUpdateEvaluation';
 import { evaluaionQueryOptions } from 'app/_api/queries/evaluation';
 import { Evaluation } from 'app/_api/types/evaluation';
 import { entries } from 'app/_util/entries';
@@ -17,6 +19,8 @@ import { entries } from 'app/_util/entries';
 import { getImageURLByKeyword, getTitleByKeywordType } from '../_util/keyword';
 
 export const ReviewContent = ({ id }: { id: string }) => {
+  const router = useRouter();
+
   const {
     data: { data },
   } = useSuspenseQuery(evaluaionQueryOptions.list(id));
@@ -58,6 +62,18 @@ export const ReviewContent = ({ id }: { id: string }) => {
 
   const resetSelectedKeywordIdList = () => setSelectedKeywordIdList([]);
 
+  const { mutate } = useUpdateEvaluation();
+
+  const onClickSaveButton = () => {
+    mutate({
+      bookId: id,
+      keywordIds: selectedKeywordIdList,
+    });
+    router.push(`/books/${id}`);
+  };
+
+  //TODO 이전 상태와 같거나 선택 아예 안했을때 비활성화
+
   return (
     <Stack className="gap-5 px-4 pb-4">
       <Stack className="rounded-2xl bg-white p-5">
@@ -94,7 +110,7 @@ export const ReviewContent = ({ id }: { id: string }) => {
         >
           초기화
         </Button>
-        <Button variant="black" className="grow">
+        <Button variant="black" className="grow" onClick={onClickSaveButton}>
           완료하기
         </Button>
       </HStack>

--- a/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
+++ b/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
@@ -4,17 +4,39 @@ import Image from 'next/image';
 
 import { useState } from 'react';
 
+import { useSuspenseQuery } from '@tanstack/react-query';
+
 import { Button } from '@repo/ui/components/Button';
 import { Chip } from '@repo/ui/components/Chip';
 import { HStack, Stack } from '@repo/ui/components/Layout';
 import { Text } from '@repo/ui/components/Text';
+import { evaluaionQueryOptions } from 'app/_api/queries/evaluation';
+import { Evaluation } from 'app/_api/types/evaluation';
 import { entries } from 'app/_util/entries';
 
-import { KEYWORD_MAP } from '../_constants/keyword';
 import { getImageURLByKeyword, getTitleByKeywordType } from '../_util/keyword';
 
-export const ReviewContent = () => {
-  const [selectedKeywordIdList, setSelectedKeywordIdList] = useState<number[]>([]);
+export const ReviewContent = ({ id }: { id: string }) => {
+  const {
+    data: { data },
+  } = useSuspenseQuery(evaluaionQueryOptions.list(id));
+
+  const groupdData = data.reduce<{ GOOD: Evaluation[]; SHAME: Evaluation[] }>(
+    (result, item) => {
+      const category = String(item.evaluationId).startsWith('1') ? 'GOOD' : 'SHAME';
+      return {
+        ...result,
+        [category]: [...(result[category] || []), item],
+      };
+    },
+    { GOOD: [], SHAME: [] }
+  );
+
+  const initialKeywordList = data
+    .filter(({ isSelected }) => isSelected)
+    .map(({ evaluationId }) => evaluationId);
+
+  const [selectedKeywordIdList, setSelectedKeywordIdList] = useState<number[]>(initialKeywordList);
 
   const onClickKeyword = (keywordId: number) => () => {
     const isExistKeywordId = selectedKeywordIdList.includes(keywordId);
@@ -40,27 +62,22 @@ export const ReviewContent = () => {
     <Stack className="gap-5 px-4 pb-4">
       <Stack className="rounded-2xl bg-white p-5">
         <Stack className="gap-8">
-          {entries(KEYWORD_MAP).map(([type, keywordList]) => (
+          {entries(groupdData).map(([type, evaluationList]) => (
             <Stack className="gap-4" key={type}>
               <Text type="Title2" weight="medium" className="text-gray-900">
                 {getTitleByKeywordType(type)}
               </Text>
               <HStack className="flex-wrap gap-3">
-                {keywordList.map(({ id, keyword, description }) => (
+                {evaluationList.map(({ evaluationId, keyword, icon }) => (
                   <Chip
                     variant="keyword"
-                    active={selectedKeywordIdList.includes(id)}
-                    key={id}
+                    active={selectedKeywordIdList.includes(evaluationId)}
+                    key={evaluationId}
                     className="gap-1"
-                    onClick={onClickKeyword(id)}
+                    onClick={onClickKeyword(evaluationId)}
                   >
-                    <Image
-                      src={getImageURLByKeyword(keyword)}
-                      alt={description}
-                      width={24}
-                      height={24}
-                    />
-                    {description}
+                    <Image src={getImageURLByKeyword(icon)} alt={keyword} width={24} height={24} />
+                    {keyword}
                   </Chip>
                 ))}
               </HStack>

--- a/apps/web/app/books/[id]/review/error.tsx
+++ b/apps/web/app/books/[id]/review/error.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+// TODO 추후 UI 변경 필요
+
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+      <button
+        onClick={
+          // 재시도
+          () => reset()
+        }
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/web/app/books/[id]/review/page.tsx
+++ b/apps/web/app/books/[id]/review/page.tsx
@@ -19,7 +19,7 @@ const ReviewPage = async ({ params }: Props) => {
 
   //TODO 추후 getQueryClient util 함수로 교체
 
-  await queryClient.prefetchQuery(evaluaionQueryOptions.list(param.id));
+  await queryClient.fetchQuery(evaluaionQueryOptions.list(param.id));
 
   return (
     <PageLayout
@@ -33,7 +33,7 @@ const ReviewPage = async ({ params }: Props) => {
       <Stack>
         <ReviewHeader />
         <HydrationBoundary state={dehydrate(queryClient)}>
-          <ReviewContent />
+          <ReviewContent id={param.id} />
         </HydrationBoundary>
       </Stack>
     </PageLayout>

--- a/apps/web/app/books/[id]/review/page.tsx
+++ b/apps/web/app/books/[id]/review/page.tsx
@@ -1,11 +1,26 @@
+import { dehydrate, HydrationBoundary, QueryClient } from '@tanstack/react-query';
+
 import { Header } from '@repo/ui/components/Header';
 import { PageLayout, Stack } from '@repo/ui/components/Layout';
 import { Text } from '@repo/ui/components/Text';
+import { evaluaionQueryOptions } from 'app/_api/queries/evaluation';
 import { BackButton } from 'app/_components/BackButton';
 
 import { ReviewContent } from './_components/ReviewContent';
 
-const ReviewPage = () => {
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+const queryClient = new QueryClient();
+
+const ReviewPage = async ({ params }: Props) => {
+  const param = await params;
+
+  //TODO 추후 getQueryClient util 함수로 교체
+
+  await queryClient.prefetchQuery(evaluaionQueryOptions.list(param.id));
+
   return (
     <PageLayout
       header={
@@ -17,7 +32,9 @@ const ReviewPage = () => {
     >
       <Stack>
         <ReviewHeader />
-        <ReviewContent />
+        <HydrationBoundary state={dehydrate(queryClient)}>
+          <ReviewContent />
+        </HydrationBoundary>
       </Stack>
     </PageLayout>
   );

--- a/apps/web/app/books/_utils/getChipIconUrl.ts
+++ b/apps/web/app/books/_utils/getChipIconUrl.ts
@@ -1,0 +1,1 @@
+export const getChipIconUrl = (iconUrl: string) => `/Chip/${iconUrl}.png`;


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #96

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
- 책 정보 페이지에서 평가 조회 api 연동
- 평가 페이지에서 평가 조회 api 연동
- 평가 페이지에서 평가 등록 api 연동
- suspensiveQuery를 사용하니까 error가 발생하면 무한 요청을 하더라구여... 그래서 위에서 preFetchQuery 대신 fetchQuery를 사용했고 error.tsx를 이용해서 에러를 캐치하게 했습니다. error.tsx는 진짜 임시로만 해놓은거라 나중에 수정해야 할 것 같아요

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->