### PR TITLE
[FIX] 리뷰 등록 후 보상 모달에서 책 정보 페이지로 이동시 router.push -> router.back으로 수정

### DIFF
--- a/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
+++ b/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
@@ -17,7 +17,6 @@ import { useUpdateEvaluation } from 'app/_api/mutations/useUpdateEvaluation';
 import { evaluaionQueryOptions } from 'app/_api/queries/evaluation';
 import { Evaluation } from 'app/_api/types/evaluation';
 import { RewardModal } from 'app/_components/RewardModal';
-import { DYNAMIC_ROUTES } from 'app/_constants/route';
 import { entries } from 'app/_util/entries';
 
 import { getImageURLByKeyword, getTitleByKeywordType } from '../_util/keyword';
@@ -139,11 +138,7 @@ export const ReviewContent = ({ id }: { id: string }) => {
           완료하기
         </Button>
       </HStack>
-      <RewardModal
-        type="single"
-        isOpen={isOpen}
-        onClose={() => router.push(DYNAMIC_ROUTES.BOOK_DETAIL(id))}
-      />
+      <RewardModal type="single" isOpen={isOpen} onClose={() => router.back()} />
     </Stack>
   );
 };


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #148 

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
- 리뷰 등록 후 보상 모달에서 책 정보 페이지로 이동시 router.push -> router.back으로 수정

## 🙏 기타 참고 사항
- 이 작업이 머지되면 책 정보 페이지에서 뒤로가기 눌렀을 시 리뷰 페이지로 가는 버그는 사라질 것 같습니다

<!-- 없다면 적지 않으셔도 됩니다. -->