### PR TITLE
[BUGFIX] overflow-scroll 스크롤바 때문에 배경이 잘리는 버그 수정

### DIFF
--- a/apps/web/app/books/_components/Card.tsx
+++ b/apps/web/app/books/_components/Card.tsx
@@ -10,16 +10,25 @@ type CardProps = {
 };
 
 export const Card = ({ imageURL, title, description }: CardProps) => {
+  const IMAGE = '/Ghost/BASIC_GHOST.webp';
+
   return (
     <Stack className="h-[204px] w-[106px] gap-1">
-      <Box className="border-gray-70 aspect-1 relative h-[156px] rounded-lg border">
-        <Image src={imageURL} alt={title} fill className="border-gray-70 rounded-lg border" />
+      <Box className="border-gray-70 relative rounded-lg border">
+        <Image
+          src={imageURL || IMAGE}
+          width={106}
+          height={156}
+          priority
+          alt={title}
+          className="border-gray-70 h-[156px] rounded-lg border object-cover"
+        />
       </Box>
       <Stack className="gap-0.5">
-        <Text type="Title2" weight="medium" className="text-gray-900">
+        <Text type="Title2" weight="medium" className="line-clamp-2 text-gray-900">
           {title}
         </Text>
-        <Text type="Title2" weight="medium" className="text-gray-400">
+        <Text type="Title2" weight="medium" className="line-clamp-1 text-gray-400">
           {description}
         </Text>
       </Stack>

--- a/apps/web/app/books/_components/CardList.tsx
+++ b/apps/web/app/books/_components/CardList.tsx
@@ -22,17 +22,13 @@ export const CardList = ({ bookList }: CardListProps) => {
   ) : (
     <VStack>
       <Spacing className="h-4" />
-      <div className="grid w-full grid-cols-3 place-content-between gap-x-3 gap-y-5">
+      <div className="grid w-full grid-cols-3 place-content-between gap-x-3 gap-y-5 pb-10">
         <Link href={ROUTES.SEARCH}>
           <AddBookCard />
         </Link>
         {bookList.map(({ id, thumbnailUrl, author, title }) => (
           <Link key={id} href={DYNAMIC_ROUTES.BOOK_DETAIL(id)}>
-            <Card
-              title={title}
-              description={author}
-              imageURL={thumbnailUrl ?? '/Ghost/BASIC_GHOST.png'}
-            />
+            <Card title={title} description={author} imageURL={thumbnailUrl} />
           </Link>
         ))}
       </div>

--- a/apps/web/app/search/_components/BookCard.tsx
+++ b/apps/web/app/search/_components/BookCard.tsx
@@ -7,7 +7,7 @@ import { Book } from 'app/_api/types/book';
 
 export type BookWithModal = Book & { openModal: () => void };
 export const BookCard = ({ title, author, publishedAt, thumbnail, openModal }: BookWithModal) => {
-  const IMAGE = '/BASIC_GHOST.webp';
+  const IMAGE = '/Ghost/BASIC_GHOST.webp';
   return (
     <Flex className="my-2 w-full flex-row items-center justify-between">
       <Flex className="flex-row items-center gap-4">

--- a/packages/ui/src/components/Layout/PageLayout/PageLayout.tsx
+++ b/packages/ui/src/components/Layout/PageLayout/PageLayout.tsx
@@ -17,7 +17,7 @@ export const PageLayout = ({
   return (
     <Stack className={cn('h-full', containerClassName)}>
       {header}
-      <div className={cn('grow overflow-scroll', className)}>{children}</div>
+      <div className={cn('grow overflow-auto', className)}>{children}</div>
     </Stack>
   );
 };


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #174

## ✨ 작업 내용

- 맥북 > 스크롤 막대 보기가 `항상` 으로 표시된 사용자는 스크롤바가 overflow와 상관없이 스크롤바가 보이는 문제였습니다. (os도 고려해야 하는..나)
- `overflow-scroll` -> `overflow-auto`로 변경해서 내용이 넘치는 경우에만 스크롤바가 보여지도록 수정했습니다. 

<img width="509" alt="image" src="https://github.com/user-attachments/assets/0ce500d4-bb9c-496d-89b5-fa5d688db174" />

- 작업하면서 `책장` 이미지 크기 고정, 기본이미지 경로 수정 했습니다~!
<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->