### PR TITLE
[BUGFIX] 꾸미기 페이지에서 저장버튼 하단에 고정

### DIFF
--- a/apps/web/app/closet/_components/ClosetSecion.tsx
+++ b/apps/web/app/closet/_components/ClosetSecion.tsx
@@ -125,7 +125,7 @@ export const ClosetSection = ({ memberId }: ClosetSectionProps) => {
       <Center className="fixed bottom-0 w-full max-w-[440px] bg-white p-4 outline-none">
         <Button
           size="lg"
-          className="w-full text-nowrap px-[140px] py-3.5"
+          className="w-full px-[140px] py-3.5"
           disabled={disabled}
           onClick={onClickSavebutton}
         >

--- a/apps/web/app/closet/_components/ClosetSecion.tsx
+++ b/apps/web/app/closet/_components/ClosetSecion.tsx
@@ -10,7 +10,7 @@ import { Button } from '@sbooky/ui/components/Button';
 import { Header, HeaderLeftElement } from '@sbooky/ui/components/Header';
 import { Icon } from '@sbooky/ui/components/Icon';
 import { IconButton } from '@sbooky/ui/components/IconButton';
-import { Box, PageLayout, Stack } from '@sbooky/ui/components/Layout';
+import { Box, Center, PageLayout, Spacing, Stack } from '@sbooky/ui/components/Layout';
 import { useUpdateEquippedItem } from 'app/_api/mutations/useUpdateEquippedItem';
 import { itemQueryOptions } from 'app/_api/queries/item';
 import { ROUTES } from 'app/_constants/route';
@@ -119,16 +119,19 @@ export const ClosetSection = ({ memberId }: ClosetSectionProps) => {
               active={item.name === currentGhost.name}
             />
           ))}
+          <Spacing className="h-[80px]" />
         </Box>
+      </Stack>
+      <Center className="fixed bottom-0 w-full max-w-[440px] bg-white p-4 outline-none">
         <Button
           size="lg"
-          className="w-full px-[140px] py-3.5"
+          className="w-full text-nowrap px-[140px] py-3.5"
           disabled={disabled}
           onClick={onClickSavebutton}
         >
           저장하기
         </Button>
-      </Stack>
+      </Center>
     </PageLayout>
   );
 };

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -84,7 +84,9 @@ export function Button({
       disabled={disabled}
       {...restProps}
     >
-      <Text {...buttonTextVariantMap[size]}>{children}</Text>
+      <Text {...buttonTextVariantMap[size]} className="text-nowrap">
+        {children}
+      </Text>
       {iconType && <Icon type={iconType} color={disabled ? 'gray600' : 'gray500'} size={16} />}
       {right}
     </button>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #191

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->
- 꾸미기 페이지에서 저장 버튼을 하단에 고정했습니다

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Closet 섹션의 레이아웃이 개선되어 저장 버튼이 화면 하단에 고정되고, 아이템 카드 사이에 적절한 간격이 추가되었습니다.
  - 버튼 텍스트가 한 줄로 유지되어 가독성과 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->