### PR TITLE
[FIX] 책 상세 페이지에서 책 카드 좌우 여백 설정

### DIFF
--- a/apps/web/app/books/[id]/_components/BookInfo.tsx
+++ b/apps/web/app/books/[id]/_components/BookInfo.tsx
@@ -23,11 +23,11 @@ export const BookInfo = ({ title, thumbnailUrl, author, publishedAt }: Props) =>
           height={206}
           className="rounded-[4px]"
         />
-        <CenterStack className="gap-1">
-          <Text type="Heading3" weight="semibold" className="text-white">
+        <CenterStack className="max-w-[140px] gap-1">
+          <Text type="Heading3" weight="semibold" className="line-clamp-1 text-white">
             {title}
           </Text>
-          <Text type="caption" weight="medium" className="text-gray-200">
+          <Text type="caption" weight="medium" className="line-clamp-1 text-gray-200">
             {author} • {publishedAt}
           </Text>
         </CenterStack>

--- a/apps/web/app/books/[id]/_components/BookInfo.tsx
+++ b/apps/web/app/books/[id]/_components/BookInfo.tsx
@@ -23,7 +23,7 @@ export const BookInfo = ({ title, thumbnailUrl, author, publishedAt }: Props) =>
           height={206}
           className="rounded-[4px]"
         />
-        <CenterStack className="max-w-[180px] gap-1">
+        <CenterStack className="max-w-[200px] gap-1">
           <Text type="Heading3" weight="semibold" className="line-clamp-1 text-white">
             {title}
           </Text>

--- a/apps/web/app/books/[id]/_components/BookInfo.tsx
+++ b/apps/web/app/books/[id]/_components/BookInfo.tsx
@@ -23,7 +23,7 @@ export const BookInfo = ({ title, thumbnailUrl, author, publishedAt }: Props) =>
           height={206}
           className="rounded-[4px]"
         />
-        <CenterStack className="max-w-[140px] gap-1">
+        <CenterStack className="max-w-[180px] gap-1">
           <Text type="Heading3" weight="semibold" className="line-clamp-1 text-white">
             {title}
           </Text>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #183

## ✨ 작업 내용

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

- 책 상세 페이지에서 책 카드의 제목, 작가의  좌우 길이 제한이 없던 문제를 수정해 ui를 개선했습니다.

<img width="347" alt="스크린샷 2025-05-09 오후 10 55 26" src="https://github.com/user-attachments/assets/cb9be23e-24d3-41f8-881f-30618ce05119" />


## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - 도서 제목과 저자명이 한 줄로 표시되며, 길이가 길 경우 말줄임표로 처리되어 레이아웃이 깔끔하게 유지됩니다.
  - 도서 제목과 저자 텍스트가 차지하는 최대 너비가 180픽셀에서 200픽셀로 확대되어 보다 안정적인 레이아웃을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->