### PR TITLE
[BUGFIX] 사용자 행동에 따라 구슬이 실시간으로 변경되지 않는 이슈 수정

### DIFF
--- a/apps/web/app/_api/mutations/useAddBook.ts
+++ b/apps/web/app/_api/mutations/useAddBook.ts
@@ -13,9 +13,14 @@ export const useAddBook = () => {
   return useMutation<Response, Error, NewBook>({
     mutationFn: (data: NewBook) => addBook(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [...bookQueryKeys.add()],
-      });
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [...bookQueryKeys.add()],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [...bookQueryKeys.point()],
+        }),
+      ]);
     },
     // TODO : 책 등록에 실패했을 경우 에러 처리
     onError: () => {},

--- a/apps/web/app/_api/mutations/useItemDraw.ts
+++ b/apps/web/app/_api/mutations/useItemDraw.ts
@@ -1,12 +1,20 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { fetcher } from '../fetcher';
+import { bookQueryKeys } from '../queries/book';
 import { ItemDrawResponse } from '../types/draw';
 
 const itemDraw = () => fetcher.post<ItemDrawResponse>('items/draw');
 
 export const useItemDraw = () => {
+  const queryClient = useQueryClient();
+
   return useMutation<ItemDrawResponse, Error>({
     mutationFn: itemDraw,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: [...bookQueryKeys.point()],
+      });
+    },
   });
 };

--- a/apps/web/app/_api/queries/book.ts
+++ b/apps/web/app/_api/queries/book.ts
@@ -56,7 +56,7 @@ export const bookQueryOptions = {
     }),
   point: () =>
     queryOptions({
-      queryKey: [...bookQueryKeys.all()],
+      queryKey: [...bookQueryKeys.point()],
       queryFn: getMemberPointAPI,
     }),
 };

--- a/apps/web/app/books/[id]/_components/BookStatusModal.tsx
+++ b/apps/web/app/books/[id]/_components/BookStatusModal.tsx
@@ -27,6 +27,7 @@ type BookStatusModalProps = ModalProps & {
   data: Book;
   initialReadState?: READING_STATUS;
   onConfirm: (readStatus: READING_STATUS) => void;
+  isPending: boolean;
   memberId?: string;
 };
 
@@ -37,6 +38,7 @@ export const BookStatusModal = ({
   onConfirm,
   initialReadState = 'WANT_TO_READ',
   memberId,
+  isPending,
 }: BookStatusModalProps) => {
   const router = useRouter();
   const path = usePathname().toString().split('/')[1];
@@ -83,7 +85,7 @@ export const BookStatusModal = ({
             <Button size="md" variant="gray100" onClick={closeModal}>
               닫기
             </Button>
-            <Button size="md" variant="black" onClick={handleSave}>
+            <Button size="md" variant="black" onClick={handleSave} disabled={isPending}>
               저장하기
             </Button>
           </JustifyBetween>

--- a/apps/web/app/books/[id]/_components/DetailSection.tsx
+++ b/apps/web/app/books/[id]/_components/DetailSection.tsx
@@ -24,7 +24,7 @@ export const DetailSection = ({ id, memberId }: { id: string; memberId?: string 
     data: { data },
   } = useSuspenseQuery(bookQueryOptions.detail(id));
 
-  const { mutate } = useDeleteBook();
+  const { mutate, isPending } = useDeleteBook();
 
   const onClickTrashButton = (bookId: string) => () => {
     if (!memberId) {
@@ -52,7 +52,7 @@ export const DetailSection = ({ id, memberId }: { id: string; memberId?: string 
           left={<BackButton />}
           right={
             data.isOwner && (
-              <HeaderRightElement onClick={onClickTrashButton(id)}>
+              <HeaderRightElement onClick={onClickTrashButton(id)} disabled={isPending}>
                 <Icon type="delete" color="gray800" />
               </HeaderRightElement>
             )

--- a/apps/web/app/books/[id]/_components/DialogTrigger.tsx
+++ b/apps/web/app/books/[id]/_components/DialogTrigger.tsx
@@ -17,7 +17,7 @@ type DialogTriggerProps = {
 export const DialogTrigger = ({ data, memberId }: DialogTriggerProps) => {
   const { isOpen, openModal, closeModal } = useModal();
 
-  const { mutate } = useUpdateBook();
+  const { mutate, isPending } = useUpdateBook();
 
   const onConfirm = (readStatus: READING_STATUS) => {
     mutate(
@@ -48,6 +48,7 @@ export const DialogTrigger = ({ data, memberId }: DialogTriggerProps) => {
           onConfirm={onConfirm}
           initialReadState={data.readStatus}
           memberId={memberId}
+          isPending={isPending}
         />
       )}
     </>

--- a/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
+++ b/apps/web/app/books/[id]/review/_components/ReviewContent.tsx
@@ -65,7 +65,7 @@ export const ReviewContent = ({ id }: { id: string }) => {
 
   const resetSelectedKeywordIdList = () => setSelectedKeywordIdList(initialKeywordList);
 
-  const { mutate } = useUpdateEvaluation();
+  const { mutate, isPending } = useUpdateEvaluation();
 
   const isInitialReview = initialKeywordList.length === 0;
 
@@ -95,7 +95,9 @@ export const ReviewContent = ({ id }: { id: string }) => {
   );
 
   const disabled =
-    selectedKeywordIdList.length === 0 || areInitialKeywordListAndSelectedKeywordIdListArrayEqual;
+    selectedKeywordIdList.length === 0 ||
+    areInitialKeywordListAndSelectedKeywordIdListArrayEqual ||
+    isPending;
 
   return (
     <Stack className="gap-5 px-4 pb-4">

--- a/apps/web/app/search/_components/BookList.tsx
+++ b/apps/web/app/search/_components/BookList.tsx
@@ -26,7 +26,7 @@ export const BookList = ({ data, isLoading, memberId }: BookListProps) => {
   const { isOpen, openModal, closeModal } = useModal();
   const isEmptyBooks = data.length === 0;
 
-  const { mutate } = useAddBook();
+  const { mutate, isPending } = useAddBook();
 
   const onConfirm = (readStatus: READING_STATUS) =>
     mutate(
@@ -80,6 +80,7 @@ export const BookList = ({ data, isLoading, memberId }: BookListProps) => {
         data={selectedBook}
         onConfirm={onConfirm}
         memberId={memberId}
+        isPending={isPending}
       />
     </Box>
   );

--- a/apps/web/app/store/_components/ItemInfo.tsx
+++ b/apps/web/app/store/_components/ItemInfo.tsx
@@ -50,7 +50,7 @@ export const ItemInfo = () => {
           className="w-full"
           right={<ButtonElement count={data?.data.drawPoint ?? 0} />}
           onClick={handleItemDraw}
-          disabled={data?.data.drawCount === 0}
+          disabled={data?.data.drawCount === 0 || mutation.isPending}
         >
           아이템 뽑기
         </Button>


### PR DESCRIPTION
<!-- PR 제목입니다. -->
<!-- 아래 중 타입에 맞는 PR 제목으로 복사/붙여넣기 해 주세요. -->
<!-- [FEAT] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [BUGFIX] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [REFACTOR] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [CHORE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [TEST] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [PERFORMANCE] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [SET] 작업_내용을_한_줄로_요약해서_작성 -->
<!-- [DOCS] 작업_내용을_한_줄로_요약해서_작성 -->

## 관련 이슈

close #220

## ✨ 작업 내용
- 아이템 뽑기, 책 등록 시에 구슬 개수 관련 쿼리 키를 invalidate해서 구슬 개수를 리패치하도록 했습니다.
  - 작업 이후에도 뽑기 시 구슬이 실시간 동기화가 안되서 tanstack query devtools를 사용해봤는데 구슬 개수 관련 쿼리 옵션에서 쿼리 키가 잘못 설정되어 있는 걸 발견하고 수정하니 해결됐습니다.
- 사용자의 클릭에 의한 중복 요청을 최대한 방지하고자 mutation 중에는 버튼을 disabled 시켰습니다. 

<!-- 이번 PR에 담긴 작업 내용을 작성합니다 -->

## 🙏 기타 참고 사항

<!-- 없다면 적지 않으셔도 됩니다. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 여러 버튼(책 저장, 삭제, 평가 완료, 아이템 뽑기 등)이 처리 중일 때 중복 클릭을 방지하기 위해 비활성화됩니다.
- **신규 기능**
  - 책 상태 모달 등 일부 컴포넌트에 처리 상태를 나타내는 isPending 속성이 추가되었습니다.
- **기타**
  - 데이터 갱신을 위해 일부 작업 완료 시 관련 정보가 더 정확하게 새로고침됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->